### PR TITLE
improve regexp for compress spaces

### DIFF
--- a/canvg.js
+++ b/canvg.js
@@ -177,7 +177,9 @@
 		svg.trim = function(s) { return s.replace(/^\s+|\s+$/g, ''); }
 
 		// compress spaces
-		svg.compressSpaces = function(s) { return s.replace(/[\s\r\t\n]+/gm,' '); }
+		// Ideographic space is not replaced
+		// behavior: http://jsfiddle.net/L3hondLn/730/
+		svg.compressSpaces = function(s) { return s.replace(/(?!\u3000)\s+/gm, ' '); }
 
 		// ajax
 		svg.ajax = function(url) {


### PR DESCRIPTION
## Why

- Fix bug
- 本家にもPR済み https://github.com/canvg/canvg/pull/517

## Summary

- remove `\r\t\n`, \s contains \r, \t and \n
- add exclude \u3000 (Ideographic space / 和字間隔)

## Testing

### Before

http://jsfiddle.net/L3hondLn/728/

### After

http://jsfiddle.net/L3hondLn/730/